### PR TITLE
Switch some policies to warn instead of deny

### DIFF
--- a/policy/replicasetHistory.rego
+++ b/policy/replicasetHistory.rego
@@ -10,7 +10,7 @@ valid_revision_history_limit {
     input.spec.revisionHistoryLimit >= 5
 }
 
-deny_replicaset_no_explicit_revision_history_limit[msg] {
+warn_replicaset_no_explicit_revision_history_limit[msg] {
     has_revision_history_limit
 
     not valid_revision_history_limit

--- a/policy/securityContext.rego
+++ b/policy/securityContext.rego
@@ -2,7 +2,7 @@ package main
 
 import data.kubernetes
 
-deny_containers_must_not_run_as_root[msg] {
+warn_containers_must_not_run_as_root[msg] {
   container := kubernetes.containers[_]
 
   not container.securityContext.runAsNonRoot
@@ -10,7 +10,7 @@ deny_containers_must_not_run_as_root[msg] {
   msg = sprintf("%v:%v must not run as root in container '%v'", [input.kind, input.metadata.name, container.name])
 }
 
-deny_containers_allowing_privilege_escalation[msg] {
+warn_containers_allowing_privilege_escalation[msg] {
   container := kubernetes.containers[_]
 
   not container.securityContext.allowPrivilegeEscalation == false


### PR DESCRIPTION
Switched some policies to warn, based on how complex they may be
to implement. e.g. not running as root may require multiple changes
but adding explicit resources should be trivial